### PR TITLE
Update umbraco-marketplace.json with correct name for category.

### DIFF
--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -5,7 +5,7 @@
     "Infocaster Telemetry Package",
     "Infocaster.Telemetry.Umbraco"
   ],
-  "Category": "Analytics and Insights",
+  "Category": "Analytics & Insights",
   "PackageType": "Package",
   "Tags": [
     "telemetry",


### PR DESCRIPTION
Hi - I noticed that the category name you had in this file wasn't exactly matching the name we have on the marketplace, which meant it wasn't being listed in the category as expected.  This rename should resolve that.